### PR TITLE
Refactor Post.razor to improve syntax highlighting logic

### DIFF
--- a/AdventCalendar/Pages/Post.razor
+++ b/AdventCalendar/Pages/Post.razor
@@ -16,11 +16,21 @@
 
     private string content = string.Empty;
 
+    private enum InitializingState
+    {
+        Loading,
+        BuiltContent,
+        SyntaxHighlighted
+    }
+
+    private InitializingState initializingState = InitializingState.Loading;
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
+        if (initializingState == InitializingState.BuiltContent)
         {
-            await JS.InvokeVoidAsync("applyPrism");
+            initializingState = InitializingState.SyntaxHighlighted;
+            await JS.InvokeVoidAsync("Prism.highlightAll");
         }
     }
 
@@ -42,6 +52,7 @@
             ImagePathRewriterExtension.RewriteImagePaths(document);
 
             content = Markdig.Markdown.ToHtml(document, pipeline);
+            initializingState = InitializingState.BuiltContent;
         }
         catch (Exception ex)
         {

--- a/AdventCalendar/wwwroot/index.html
+++ b/AdventCalendar/wwwroot/index.html
@@ -31,7 +31,6 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="js/prism-init.js"></script>
 
 </body>
 

--- a/AdventCalendar/wwwroot/js/prism-init.js
+++ b/AdventCalendar/wwwroot/js/prism-init.js
@@ -1,5 +1,0 @@
-﻿window.applyPrism = function () {
-    setTimeout(function () {
-        Prism.highlightAll();
-    }, 50);
-};


### PR DESCRIPTION
...and remove unused `prism-init.js`.

This pull request will also fix another problem: syntax highlighting still won't work when fetching a markdown process takes longer than 50 msec.